### PR TITLE
Fix spontaneous high CPU usage by Spotify

### DIFF
--- a/spotify_remote.py
+++ b/spotify_remote.py
@@ -142,7 +142,7 @@ class SpotifyRemote(object):
     def version(self):
         return self._call("/service/version.json", service="remote")
 
-    def status(self, return_after=-1, return_on=DEFAULT_RETURN_ON):
+    def status(self, return_after=0, return_on=DEFAULT_RETURN_ON):
         return self._call("/remote/status.json",
                           authed=True,
                           returnafter=return_after,


### PR DESCRIPTION
`return_after` set to -1 can cause spontaneous high CPU usage by the Spotify client.
Setting `return_after` to 0 fixes this. Timeout remains disabled.